### PR TITLE
Add DW_TAG_string_type as acceptable to the Verifier

### DIFF
--- a/lib/IR/Verifier.cpp
+++ b/lib/IR/Verifier.cpp
@@ -861,7 +861,8 @@ void Verifier::visitDIEnumerator(const DIEnumerator &N) {
 
 void Verifier::visitDIBasicType(const DIBasicType &N) {
   AssertDI(N.getTag() == dwarf::DW_TAG_base_type ||
-               N.getTag() == dwarf::DW_TAG_unspecified_type,
+               N.getTag() == dwarf::DW_TAG_unspecified_type ||
+               N.getTag() == dwarf::DW_TAG_string_type,
            "invalid tag", &N);
 }
 


### PR DESCRIPTION
Add the DW_TAG_string_type tag as an acceptable tag to the verifier for Fortran's CHARACTER type.