### PR TITLE
[FLANG] Move the Fortran flags on 'master' so they don't conflict with new

### DIFF
--- a/include/llvm/IR/DebugInfoFlags.def
+++ b/include/llvm/IR/DebugInfoFlags.def
@@ -43,11 +43,11 @@ HANDLE_DI_FLAG((1 << 18), IntroducedVirtual)
 HANDLE_DI_FLAG((1 << 19), BitField)
 HANDLE_DI_FLAG((1 << 20), NoReturn)
 HANDLE_DI_FLAG((1 << 21), MainSubprogram)
-HANDLE_DI_FLAG((1 << 22), Pure)
-HANDLE_DI_FLAG((1 << 23), Elemental)
-HANDLE_DI_FLAG((1 << 24), Recursive)
-HANDLE_DI_FLAG((1 << 25), TypePassByValue)
-HANDLE_DI_FLAG((1 << 26), TypePassByReference)
+HANDLE_DI_FLAG((1 << 22), TypePassByValue)
+HANDLE_DI_FLAG((1 << 23), TypePassByReference)
+HANDLE_DI_FLAG((1 << 24), Pure)
+HANDLE_DI_FLAG((1 << 25), Elemental)
+HANDLE_DI_FLAG((1 << 26), Recursive)
 
 // To avoid needing a dedicated value for IndirectVirtualBase, we use
 // the bitwise or of Virtual and FwdDecl, which does not otherwise


### PR DESCRIPTION
TypePassByValue and TypePassByReference flags.

(Flang currently uses release_50, which has different values for the Fortran flags.)
