### PR TITLE
Change for SLES 11 support. 

### DIFF
--- a/lib/Support/Unix/Threading.inc
+++ b/lib/Support/Unix/Threading.inc
@@ -141,6 +141,7 @@ void llvm::set_thread_name(const Twine &Name) {
   if (get_max_thread_name_length() > 0)
     NameStr = NameStr.take_back(get_max_thread_name_length());
   (void)NameStr;
+#if 0
 #if defined(__linux__)
 #if (defined(__GLIBC__) && defined(_GNU_SOURCE)) || defined(__ANDROID__)
 #if HAVE_PTHREAD_SETNAME_NP
@@ -154,6 +155,7 @@ void llvm::set_thread_name(const Twine &Name) {
     const_cast<char *>(NameStr.data()));
 #elif defined(__APPLE__)
   ::pthread_setname_np(NameStr.data());
+#endif
 #endif
 }
 
@@ -203,12 +205,14 @@ void llvm::get_thread_name(SmallVectorImpl<char> &Name) {
 
   Name.append(buf, buf + strlen(buf));
 #elif defined(__linux__)
+#if 0
 #if (defined(__GLIBC__) && defined(_GNU_SOURCE)) || defined(__ANDROID__)
 #if HAVE_PTHREAD_GETNAME_NP
   constexpr uint32_t len = get_max_thread_name_length_impl();
   char Buffer[len] = {'\0'};  // FIXME: working around MSan false positive.
   if (0 == ::pthread_getname_np(::pthread_self(), Buffer, len))
     Name.append(Buffer, Buffer + strlen(Buffer));
+#endif
 #endif
 #endif
 #endif


### PR DESCRIPTION
We don't want to include calls to pthread_[sg]etname_np() as they are glibc 2.12 functions and SLES uses glibc 2.11 by default.