### PR TITLE
[GlobalISel] Handle multiple registers in dbg.value intrinsic

### DIFF
--- a/lib/CodeGen/GlobalISel/IRTranslator.cpp
+++ b/lib/CodeGen/GlobalISel/IRTranslator.cpp
@@ -868,12 +868,13 @@ bool IRTranslator::translateKnownIntrinsic(const CallInst &CI, Intrinsic::ID ID,
     } else if (const auto *CI = dyn_cast<Constant>(V)) {
       MIRBuilder.buildConstDbgValue(*CI, DI.getVariable(), DI.getExpression());
     } else {
-      unsigned Reg = getOrCreateVReg(*V);
-      // FIXME: This does not handle register-indirect values at offset 0. The
-      // direct/indirect thing shouldn't really be handled by something as
-      // implicit as reg+noreg vs reg+imm in the first palce, but it seems
-      // pretty baked in right now.
-      MIRBuilder.buildDirectDbgValue(Reg, DI.getVariable(), DI.getExpression());
+      for (unsigned Reg : getOrCreateVRegs(*V)) {
+        // FIXME: This does not handle register-indirect values at offset 0. The
+        // direct/indirect thing shouldn't really be handled by something as
+        // implicit as reg+noreg vs reg+imm in the first place, but it seems
+        // pretty baked in right now.
+        MIRBuilder.buildDirectDbgValue(Reg, DI.getVariable(), DI.getExpression());
+      }
     }
     return true;
   }

--- a/test/CodeGen/Generic/DbgValueAggregate.ll
+++ b/test/CodeGen/Generic/DbgValueAggregate.ll
@@ -1,0 +1,36 @@
+; RUN: llc -O0 -global-isel < %s | FileCheck %s
+; REQUIRES: aarch64
+target triple = "aarch64-unknown-linux-gnu"
+
+define void @MAIN_() #0 {
+L.entry:
+  %0 = load <{ float, float }>, <{ float, float }>* undef, align 1
+  ; CHECK: DEBUG_VALUE: localvar
+  ; CHECK: DEBUG_VALUE: localvar
+  call void @llvm.dbg.value(metadata <{ float, float }> %0, metadata !10, metadata !DIExpression()), !dbg !13
+  unreachable
+}
+
+; Function Attrs: nounwind readnone speculatable
+declare void @llvm.dbg.value(metadata, metadata, metadata) #1
+
+attributes #0 = { "no-frame-pointer-elim-non-leaf" }
+attributes #1 = { nounwind readnone speculatable }
+
+!llvm.module.flags = !{!0}
+!llvm.dbg.cu = !{!1}
+
+!0 = !{i32 2, !"Debug Info Version", i32 3}
+!1 = distinct !DICompileUnit(language: DW_LANG_Fortran90, file: !2, producer: "", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !3, retainedTypes: !3, globals: !3, imports: !4)
+!2 = !DIFile(filename: "input", directory: "/")
+!3 = !{}
+!4 = !{!5}
+!5 = !DIImportedEntity(tag: DW_TAG_imported_module, scope: !6, entity: !9, file: !2, line: 18)
+!6 = distinct !DISubprogram(name: "p", scope: !1, file: !2, line: 18, type: !7, isLocal: false, isDefinition: true, scopeLine: 18, isOptimized: false, unit: !1)
+!7 = !DISubroutineType(cc: DW_CC_program, types: !8)
+!8 = !{null}
+!9 = !DIModule(scope: !1, name: "mod")
+!10 = !DILocalVariable(name: "localvar", scope: !11, file: !2, type: !12)
+!11 = !DILexicalBlock(scope: !6, file: !2, line: 18, column: 1)
+!12 = !DIBasicType(name: "complex", size: 64, align: 32, encoding: DW_ATE_complex_float)
+!13 = !DILocation(line: 0, scope: !11)


### PR DESCRIPTION
This is a minor variation of the patch which was upstreamed in D66077 and submitted in #77
for the change in the return type of getOrCreateVRegs.

See also: #77 for release_90 branch.
See also: https://reviews.llvm.org/D66077

The value passed into dbg.value may relate to multiple registers,
each of which need a DBG_VALUE.

This fix calls MIRBuilder.buildDirectDbgValue for each register.

Without this, IR passed in from flang-compiler/flang may fail an assertion in getOrCreateVReg.

Patch by : peterwaller-arm.

llvm-svn: 369403
Signed-off-by: Peter Waller <peter.waller@arm.com>