### PR TITLE
Enable github actions for llvm

### DIFF
--- a/.github/workflows/build_llvm.yml
+++ b/.github/workflows/build_llvm.yml
@@ -1,0 +1,58 @@
+name: CI
+
+on:
+  push:
+    branches: [ release_90 ]
+  schedule:
+    # Github only holds artifacts for 90 days, so run the job also
+    # at 00:00 on day-of-month 1 in every 2nd month from January through December.
+    - cron: '0 0 1 1/2 *'
+    
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        target: [X86, AArch64, PowerPC]
+
+    steps:
+      - name: Check tools
+        run: |
+          pwd
+          git --version
+          cmake --version
+          make --version
+          gcc --version
+          
+      - name: Build llvm
+        run: |
+          # exit the llvm dir, so the path is the same on subsequent projects
+          cd ../..
+          rm -rf llvm
+          # clone manually, because checkout does not allow exiting llvm dir
+          git clone --depth 1 --single-branch --branch release_90 https://github.com/flang-compiler/llvm.git
+          cd llvm
+          # After build place the artifacts in llvm/llvm, so Upload can find them.
+          mkdir llvm
+          CMAKE_OPTIONS="-DLLVM_TARGETS_TO_BUILD=${{ matrix.target }} \
+            -DCMAKE_INSTALL_PREFIX=/usr/local \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER=/usr/bin/gcc-9 \
+            -DCMAKE_CXX_COMPILER=/usr/bin/g++-9"
+          mkdir -p build && cd build
+          cmake $CMAKE_OPTIONS ..
+          make -j$(nproc)
+          # Install so the flang-driver can be built
+          sudo make install
+          
+          # Archive the source + build directories for future installation
+          cd ../..
+          tar -zcf llvm_build.tar.gz llvm
+          # Upload will only look in $GITHUB_WORKSPACE or its subdirs.
+          mv llvm_build.tar.gz llvm/llvm/.
+      
+      - name: Upload llvm
+        uses: actions/upload-artifact@v2
+        with:
+          name: llvm_build_${{ matrix.target }}
+          path: llvm_build.tar.gz


### PR DESCRIPTION
The action will build llvm according to [flang build instructions](https://github.com/flang-compiler/flang/wiki/Building-Flang) and upload the resulting artifacts for subsequent flows to use.
The purpose is to be able to build [flang-driver](https://github.com/flang-compiler/flang-driver/pull/94) and [flang](https://github.com/flang-compiler/flang/pull/943) in subsequent steps.
Optionally, we can also enable this action to run on PRs, but it takes about 1 hour to complete the build.
An example of a complete action can be viewed [here](https://github.com/michalpasztamobica/llvm/actions/runs/320389799).

FYI, @RichBarton-Arm